### PR TITLE
fix bug of key order when key contains a zero value

### DIFF
--- a/critbit_test.go
+++ b/critbit_test.go
@@ -184,3 +184,35 @@ func TestAllprefixed(t *testing.T) {
 		}
 	}
 }
+
+func TestKeyContainsZeroValue(t *testing.T) {
+	trie := critbitgo.NewTrie()
+	trie.Insert([]byte{1, 0, 1}, nil)
+	trie.Insert([]byte{1}, nil)
+	trie.Insert([]byte{0, 1, 1}, nil)
+	trie.Insert([]byte{}, nil)
+	trie.Insert([]byte{0, 0, 1}, nil)
+	trie.Insert([]byte{1, 1}, nil)
+	trie.Insert([]byte{1, 1, 1}, nil)
+	trie.Insert([]byte{0, 1}, nil)
+
+	var index int
+	exp := [][]byte{
+		[]byte{},
+		[]byte{0, 0, 1},
+		[]byte{0, 1},
+		[]byte{0, 1, 1},
+		[]byte{1},
+		[]byte{1, 0, 1},
+		[]byte{1, 1},
+		[]byte{1, 1, 1},
+	}
+	handle := func(key []byte, _ interface{}) bool {
+		if !bytes.Equal(exp[index], key) {
+			t.Errorf("Key Order - index=%d, expected [%x], actula [%x]", index, exp[index], key)
+		}
+		index += 1
+		return true
+	}
+	trie.Allprefixed([]byte(""), handle)
+}


### PR DESCRIPTION
Test code:

``` go
package main

import (
        "bytes"
        "fmt"

        "github.com/k-sone/critbitgo"
)

func main() {
        t := critbitgo.NewTrie()
        t.Insert([]byte{1}, nil)
        t.Insert([]byte{1, 1}, nil)
        t.Insert([]byte{1, 0, 1}, nil)

        buf := bytes.NewBufferString("")
        t.Dump(buf)
        fmt.Println(buf.String())
}
```

Actual:

```
-- off=1, bit=00000001 (01)
 |-- off=1, bit=00000000 (00)
 | |-- key=[1 0 1] (010001)
 | `-- key=[1] (01)
 `-- key=[1 1] (0101)
```

Expected:

```
-- off=1, bit=00000001 (01)
 |-- key=[1] (01)
 `-- off=1, bit=00000001 (01)
   |-- key=[1 0 1] (010001)
   `-- key=[1 1] (0101)
```
