### PR TITLE
AddingPowerSupport_golang-github-k-sone-critbitgo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+arch: 
+    - ppc64le
+    - amd64
+    
 language: go
 
 go:


### PR DESCRIPTION
Here is the summary of commits & Travis.yml modifications.,
Adding power support ppc64le.
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.

The build is successful for both Intel/Power arch types.
Here is the Travis Link: https://travis-ci.com